### PR TITLE
Dropping Python2 support

### DIFF
--- a/gitinspector.py
+++ b/gitinspector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 #
 # Copyright © 2015 Ejwa Software. All rights reserved.

--- a/gitinspector/blame.py
+++ b/gitinspector/blame.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import datetime
 import multiprocessing
 import re

--- a/gitinspector/changes.py
+++ b/gitinspector/changes.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import unicode_literals
 import bisect
 import datetime
 import multiprocessing

--- a/gitinspector/clone.py
+++ b/gitinspector/clone.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
 import os
 import shutil
 import subprocess

--- a/gitinspector/comment.py
+++ b/gitinspector/comment.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-
 __comment_begining__ = {
     "java": "/*", "c": "/*", "cc": "/*", "cpp": "/*",
     "cs": "/*", "h": "/*", "hh": "/*", "hpp": "/*",

--- a/gitinspector/config.py
+++ b/gitinspector/config.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
 import os
 import subprocess
 from . import extensions, filtering, format, interval, optval

--- a/gitinspector/extensions.py
+++ b/gitinspector/extensions.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-
 DEFAULT_EXTENSIONS = ["java", "c", "cc", "cpp", "h", "hh", "hpp", "py", "glsl", "rb", "js", "sql"]
 
 __extensions__ = DEFAULT_EXTENSIONS

--- a/gitinspector/filtering.py
+++ b/gitinspector/filtering.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
 import re
 import subprocess
 

--- a/gitinspector/format.py
+++ b/gitinspector/format.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import base64
 import os
 import textwrap

--- a/gitinspector/gitinspector.py
+++ b/gitinspector/gitinspector.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import atexit
 import getopt
 import os

--- a/gitinspector/gravatar.py
+++ b/gitinspector/gravatar.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
 import hashlib
 
 try:

--- a/gitinspector/help.py
+++ b/gitinspector/help.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import sys
 from .extensions import DEFAULT_EXTENSIONS
 from .format import __available_formats__

--- a/gitinspector/interval.py
+++ b/gitinspector/interval.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-
 try:
     from shlex import quote
 except ImportError:

--- a/gitinspector/localization.py
+++ b/gitinspector/localization.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import gettext
 import locale
 import os

--- a/gitinspector/metrics.py
+++ b/gitinspector/metrics.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
 import re
 import subprocess
 from .changes import FileDiff

--- a/gitinspector/optval.py
+++ b/gitinspector/optval.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
 import getopt
 
 class InvalidOptionArgument(Exception):

--- a/gitinspector/output/blameoutput.py
+++ b/gitinspector/output/blameoutput.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import json
 import sys
 import textwrap

--- a/gitinspector/output/changesoutput.py
+++ b/gitinspector/output/changesoutput.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import json
 import textwrap
 from ..localization import N_

--- a/gitinspector/output/extensionsoutput.py
+++ b/gitinspector/output/extensionsoutput.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import textwrap
 from ..localization import N_
 from .. import extensions, terminal

--- a/gitinspector/output/filteringoutput.py
+++ b/gitinspector/output/filteringoutput.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import textwrap
 from ..localization import N_
 from ..filtering import __filters__, has_filtered

--- a/gitinspector/output/metricsoutput.py
+++ b/gitinspector/output/metricsoutput.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 from ..changes import FileDiff
 from ..localization import N_
 from ..metrics import (__metric_eloc__, METRIC_CYCLOMATIC_COMPLEXITY_THRESHOLD, METRIC_CYCLOMATIC_COMPLEXITY_DENSITY_THRESHOLD)

--- a/gitinspector/output/outputable.py
+++ b/gitinspector/output/outputable.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 from .. import format
 
 class Outputable(object):

--- a/gitinspector/output/responsibilitiesoutput.py
+++ b/gitinspector/output/responsibilitiesoutput.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import textwrap
 from ..localization import N_
 from .. import format, gravatar, terminal

--- a/gitinspector/output/timelineoutput.py
+++ b/gitinspector/output/timelineoutput.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import textwrap
 from ..localization import N_
 from .. import format, gravatar, terminal, timeline

--- a/gitinspector/responsibilities.py
+++ b/gitinspector/responsibilities.py
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
-
 class ResponsibiltyEntry(object):
     blames = {}
 

--- a/gitinspector/terminal.py
+++ b/gitinspector/terminal.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
 import codecs
 import os
 import platform

--- a/gitinspector/timeline.py
+++ b/gitinspector/timeline.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
 import datetime
 
 class TimelineData(object):

--- a/gitinspector/version.py
+++ b/gitinspector/version.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with gitinspector. If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-from __future__ import unicode_literals
 from . import localization
 localization.init()
 


### PR DESCRIPTION
We may drop the Python2 support with this patch. Nowadays Python3 is widely used as default interpreter on many distributions. We might want to narrow a bit the number of versions of Python interpreter we support.

This is just a possibility, the patch is here and will be probably robust for a long time (it does not cross lines that may be changed in the future).

Think about it.